### PR TITLE
Add `validateZeebe` API

### DIFF
--- a/lib/Validator.js
+++ b/lib/Validator.js
@@ -1,13 +1,8 @@
-import {
-  filter,
-  forEach
-} from 'min-dash';
-
-import jsonMap from 'json-source-map';
-
 import { version as schemaVersion } from '@camunda/element-templates-json-schema/package.json';
 
 import validateTemplate from './validate';
+
+import { _validate, _validateAll } from './helper/validator';
 
 
 export function getSchemaVersion() {
@@ -21,36 +16,7 @@ export function getSchemaVersion() {
  * @return {Object} single object validation result
  */
 export function validate(object) {
-  const dataPointerMap = generateDataPointerMap(object);
-
-  const valid = validateTemplate(object);
-
-  let errors = validateTemplate.errors;
-
-  if (errors && errors.length) {
-
-    // @pinussilvestrus: the <ajv-errors> extensions produces a couple of
-    // unnecessary errors when using an <errorMessage> attribute.
-    // Therefore, we should flatten the produced errors a bit to not
-    // confuse the consumer of this library.
-
-    // (1) wrap raw errors in case of custom errorMessage attribute
-    forEach(errors, wrapRawErrors);
-
-    // (2) ignore supportive error messages (e.g. "if-then-rules")
-    errors = ignoreSupportiveErrors(errors);
-
-    // (3) set data pointer for each error
-    forEach(errors, function(error) {
-      setDataPointer(error, dataPointerMap);
-    });
-  }
-
-  return {
-    valid: valid,
-    object: object,
-    errors: errors
-  };
+  return _validate(object, validateTemplate);
 }
 
 /**
@@ -60,79 +26,5 @@ export function validate(object) {
  * @return {Object} list validation result
  */
 export function validateAll(objects) {
-
-  const results = [];
-
-  let allValid = true;
-
-  forEach(objects, function(object) {
-    const result = validate(object);
-
-    if (!result.valid) {
-      allValid = false;
-    }
-
-    results.push(result);
-  });
-
-  return {
-    valid: allValid,
-    results: results
-  };
-}
-
-
-// helper //////////////
-function wrapRawErrors(error) {
-  const params = error.params;
-
-  if (params && params.errors) {
-    params.rawErrors = params.errors;
-    delete params.errors;
-  }
-}
-
-function setDataPointer(error, dataPointerMap) {
-  const dataPath = error.dataPath;
-
-  const pointer = dataPointerMap[dataPath];
-
-  error.dataPointer = pointer;
-}
-
-function ignoreSupportiveErrors(errors) {
-  return filter(errors, function(error) {
-    return error.keyword !== 'if';
-  });
-}
-
-/**
- * Generates a key-pointer map for the object.
- *
- * Example:
- *
- * {
- *  foo: 'bar'
- * }
- *
- * =>
- *
- * {
- *  '': {
- *    value: { line: 0, column: 0, pos: 0 },
- *    valueEnd: { line: 2, column: 1, pos: 18 }
- *  },
- *  '/foo': {
- *    key: { line: 1, column: 2, pos: 4 },
- *    keyEnd: { line: 1, column: 7, pos: 9 },
- *    value: { line: 1, column: 9, pos: 11 },
- *    valueEnd: { line: 1, column: 14, pos: 16 }
- *  }
- * }
- *
- * @param {Object} object
- * @return {Object}
- */
-function generateDataPointerMap(object) {
-  return jsonMap.stringify(object, null, 2).pointers;
+  return _validateAll(objects, validate);
 }

--- a/lib/Validator.js
+++ b/lib/Validator.js
@@ -1,4 +1,4 @@
-import { version as schemaVersion } from '@camunda/element-templates-json-schema/package.json';
+import { version as schemaVersion, name as schemaPackage } from '@camunda/element-templates-json-schema/package.json';
 
 import validateTemplate from './validate';
 
@@ -7,6 +7,10 @@ import { _validate, _validateAll } from './helper/validator';
 
 export function getSchemaVersion() {
   return schemaVersion;
+}
+
+export function getSchemaPackage() {
+  return schemaPackage;
 }
 
 /**

--- a/lib/ZeebeValidator.js
+++ b/lib/ZeebeValidator.js
@@ -1,9 +1,13 @@
-import { version as schemaVersion } from '@camunda/zeebe-element-templates-json-schema/package.json';
+import { version as schemaVersion, name as schemaPackage } from '@camunda/zeebe-element-templates-json-schema/package.json';
 
 import validateTemplate from './validateZeebe';
 
 import { _validate, _validateAll } from './helper/validator';
 
+
+export function getZeebeSchemaPackage() {
+  return schemaPackage;
+}
 
 export function getZeebeSchemaVersion() {
   return schemaVersion;

--- a/lib/ZeebeValidator.js
+++ b/lib/ZeebeValidator.js
@@ -1,0 +1,30 @@
+import { version as schemaVersion } from '@camunda/zeebe-element-templates-json-schema/package.json';
+
+import validateTemplate from './validateZeebe';
+
+import { _validate, _validateAll } from './helper/validator';
+
+
+export function getZeebeSchemaVersion() {
+  return schemaVersion;
+}
+
+/**
+ * Validate a single object.
+ *
+ * @param {Object} object
+ * @return {Object} single object validation result
+ */
+export function validateZeebe(object) {
+  return _validate(object, validateTemplate);
+}
+
+/**
+ * Validate a list of objects
+ *
+ * @param  {Object[]} objects
+ * @return {Object} list validation result
+ */
+export function validateAllZeebe(objects) {
+  return _validateAll(objects, validateZeebe);
+}

--- a/lib/helper/createAjvInstance.js
+++ b/lib/helper/createAjvInstance.js
@@ -1,0 +1,15 @@
+import Ajv from 'ajv';
+import addAjvErrors from 'ajv-errors';
+
+export default function() {
+  const ajvInstance = new Ajv({
+    allErrors: true,
+    strict: false,
+    code: {
+      source: true
+    }
+  });
+  addAjvErrors(ajvInstance);
+
+  return ajvInstance;
+}

--- a/lib/helper/validator.js
+++ b/lib/helper/validator.js
@@ -1,0 +1,118 @@
+import {
+  filter,
+  forEach
+} from 'min-dash';
+
+import jsonMap from 'json-source-map';
+
+
+export function _validate(object, validateFn) {
+  const dataPointerMap = generateDataPointerMap(object);
+
+  const valid = validateFn(object);
+
+  let errors = validateFn.errors;
+
+  if (errors && errors.length) {
+
+    // @pinussilvestrus: the <ajv-errors> extensions produces a couple of
+    // unnecessary errors when using an <errorMessage> attribute.
+    // Therefore, we should flatten the produced errors a bit to not
+    // confuse the consumer of this library.
+
+    // (1) wrap raw errors in case of custom errorMessage attribute
+    forEach(errors, wrapRawErrors);
+
+    // (2) ignore supportive error messages (e.g. "if-then-rules")
+    errors = ignoreSupportiveErrors(errors);
+
+    // (3) set data pointer for each error
+    forEach(errors, function(error) {
+      setDataPointer(error, dataPointerMap);
+    });
+  }
+
+  return {
+    valid: valid,
+    object: object,
+    errors: errors
+  };
+}
+
+export function _validateAll(objects, validateFn) {
+
+  const results = [];
+
+  let allValid = true;
+
+  forEach(objects, function(object) {
+    const result = validateFn(object);
+
+    if (!result.valid) {
+      allValid = false;
+    }
+
+    results.push(result);
+  });
+
+  return {
+    valid: allValid,
+    results: results
+  };
+}
+
+
+// helper //////////////
+function wrapRawErrors(error) {
+  const params = error.params;
+
+  if (params && params.errors) {
+    params.rawErrors = params.errors;
+    delete params.errors;
+  }
+}
+
+function setDataPointer(error, dataPointerMap) {
+  const dataPath = error.dataPath;
+
+  const pointer = dataPointerMap[dataPath];
+
+  error.dataPointer = pointer;
+}
+
+function ignoreSupportiveErrors(errors) {
+  return filter(errors, function(error) {
+    return error.keyword !== 'if';
+  });
+}
+
+/**
+ * Generates a key-pointer map for the object.
+ *
+ * Example:
+ *
+ * {
+ *  foo: 'bar'
+ * }
+ *
+ * =>
+ *
+ * {
+ *  '': {
+ *    value: { line: 0, column: 0, pos: 0 },
+ *    valueEnd: { line: 2, column: 1, pos: 18 }
+ *  },
+ *  '/foo': {
+ *    key: { line: 1, column: 2, pos: 4 },
+ *    keyEnd: { line: 1, column: 7, pos: 9 },
+ *    value: { line: 1, column: 9, pos: 11 },
+ *    valueEnd: { line: 1, column: 14, pos: 16 }
+ *  }
+ * }
+ *
+ * @param {Object} object
+ * @return {Object}
+ */
+function generateDataPointerMap(object) {
+  return jsonMap.stringify(object, null, 2).pointers;
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,1 +1,2 @@
 export * from './Validator';
+export * from './ZeebeValidator';

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,16 +1,8 @@
-import Ajv from 'ajv';
-import addAjvErrors from 'ajv-errors';
+import createAjvInstance from './helper/createAjvInstance';
 
 import schema from '@camunda/element-templates-json-schema/resources/schema.json';
 
-const ajvInstance = new Ajv({
-  allErrors: true,
-  strict: false,
-  code: {
-    source: true
-  }
-});
-addAjvErrors(ajvInstance);
+const ajvInstance = createAjvInstance();
 
 export default ajvInstance.compile(schema);
 export const ajv = ajvInstance;

--- a/lib/validateZeebe.js
+++ b/lib/validateZeebe.js
@@ -1,0 +1,8 @@
+import createAjvInstance from './helper/createAjvInstance';
+
+import schema from '@camunda/zeebe-element-templates-json-schema/resources/schema.json';
+
+const ajvInstance = createAjvInstance();
+
+export default ajvInstance.compile(schema);
+export const ajv = ajvInstance;

--- a/package-lock.json
+++ b/package-lock.json
@@ -197,6 +197,11 @@
       "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.6.0.tgz",
       "integrity": "sha512-sfNIOKSfx/VQesCe1+m1izfIZS64NWDZq3teyMzzfJkn37u0ngwIwEXlc7Voj8Qcg2paePT8HmEgp+TJP39V3Q=="
     },
+    "@camunda/zeebe-element-templates-json-schema": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.1.0.tgz",
+      "integrity": "sha512-E5mie+Q+/0Rk12GerNRWZP6aIWFXo4KfC++6tFJUvKt8la4ZvsPpagB7F8Oiahd56/gUqOicJ7+yPyQ85JnFgA=="
+    },
     "@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -193,9 +193,9 @@
       }
     },
     "@camunda/element-templates-json-schema": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.6.0.tgz",
-      "integrity": "sha512-sfNIOKSfx/VQesCe1+m1izfIZS64NWDZq3teyMzzfJkn37u0ngwIwEXlc7Voj8Qcg2paePT8HmEgp+TJP39V3Q=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.7.0.tgz",
+      "integrity": "sha512-ylBhHzAuzQjX+ZoZTPinHCsIaMa89fqyk10sxVQjgEm63+o40KMomjKf4EM2sXwiy72vDbjeXyb3Z56a7MTETQ=="
     },
     "@camunda/zeebe-element-templates-json-schema": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@camunda/element-templates-json-schema": "^0.6.0",
+    "@camunda/zeebe-element-templates-json-schema": "^0.1.0",
     "json-source-map": "^0.6.1",
     "min-dash": "^3.8.1"
   }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "rollup": "^2.66.1"
   },
   "dependencies": {
-    "@camunda/element-templates-json-schema": "^0.6.0",
+    "@camunda/element-templates-json-schema": "^0.7.0",
     "@camunda/zeebe-element-templates-json-schema": "^0.1.0",
     "json-source-map": "^0.6.1",
     "min-dash": "^3.8.1"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,10 @@ import commonjs from '@rollup/plugin-commonjs';
 import alias from '@rollup/plugin-alias';
 
 import pkg from './package.json';
-import { createStandaloneValidator } from './tasks/createStandaloneValidator.js';
+import {
+  createStandaloneValidator,
+  createStandaloneZeebeValidator
+} from './tasks/createStandaloneValidator.js';
 
 
 const srcEntry = pkg.source;
@@ -22,7 +25,8 @@ export default [
     plugins: [
       alias({
         entries: {
-          './validate': createStandaloneValidator()
+          './validate': createStandaloneValidator(),
+          './validateZeebe': createStandaloneZeebeValidator()
         }
       }),
       json(),

--- a/tasks/createStandaloneValidator.js
+++ b/tasks/createStandaloneValidator.js
@@ -4,10 +4,28 @@ import { join as pathJoin, dirname } from 'path';
 
 import validate, { ajv } from '../lib/validate';
 
+import validateZeebe, { ajv as zeebeAjv } from '../lib/validateZeebe';
+
 
 export function createStandaloneValidator() {
   const code = standaloneCode(ajv, validate);
   const filePath = pathJoin('tmp', 'standaloneValidator.js');
+
+  try {
+    mkdir(dirname(filePath));
+  } catch {
+
+    // directory may already exist
+  }
+
+  writeFile(filePath, code);
+
+  return filePath;
+}
+
+export function createStandaloneZeebeValidator() {
+  const code = standaloneCode(zeebeAjv, validateZeebe);
+  const filePath = pathJoin('tmp', 'standaloneZeebeValidator.js');
 
   try {
     mkdir(dirname(filePath));

--- a/test/distro/distroSpec.js
+++ b/test/distro/distroSpec.js
@@ -8,11 +8,21 @@ describe('validate module', function() {
   it('should expose CJS bundle', function() {
 
     // given
-    const { validate, validateAll, getSchemaVersion } = require('../../dist');
+    const {
+      validate,
+      validateAll,
+      getSchemaVersion,
+      validateZeebe,
+      validateAllZeebe,
+      getZeebeSchemaVersion
+    } = require('../../dist');
 
     // then
     expect(validate).to.exist;
     expect(validateAll).to.exist;
     expect(getSchemaVersion).to.exist;
+    expect(validateZeebe).to.exist;
+    expect(validateAllZeebe).to.exist;
+    expect(getZeebeSchemaVersion).to.exist;
   });
 });

--- a/test/fixtures/multiple-connectors-errors.json
+++ b/test/fixtures/multiple-connectors-errors.json
@@ -1,0 +1,231 @@
+[
+  {
+    "name": "REST Connector",
+    "id": "io.camunda.connectors.RestConnector-s1",
+    "description": "A generic REST service.",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "http",
+        "binding": {
+          "type": "zeebe:taskDefinition:foo"
+        }
+      },
+      {
+        "label": "REST Endpoint URL",
+        "description": "Specify the url of the REST API to talk to.",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "url"
+        },
+        "constraints": {
+          "notEmpty": true,
+          "pattern": {
+            "value": "^https?://.*",
+            "message": "Must be http(s) URL."
+          }
+        }
+      },
+      {
+        "label": "REST Method",
+        "description": "Specify the HTTP method to use.",
+        "type": "Dropdown",
+        "value": "get",
+        "choices": [
+          { "name": "GET", "value": "get" },
+          { "name": "POST", "value": "post" },
+          { "name": "PATCH", "value": "patch" },
+          { "name": "DELETE", "value": "delete" }
+        ],
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "method"
+        }
+      },
+      {
+        "label": "Request Body",
+        "description": "Data to send to the endpoint.",
+        "value": "",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "body"
+        }
+      },
+      {
+        "label": "Result Variable",
+        "description": "Name of variable to store the response data in.",
+        "value": "response",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:output",
+          "source": "= body"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Rest Connector 2",
+    "id": "io.camunda.connectors.RestConnector-2",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "label": "REST Method",
+        "description": "Specify the HTTP method to use.",
+        "type": "Dropdown",
+        "value": "get",
+        "choices": [
+          { "name": "GET", "value": "get" },
+          { "name": "POST", "value": "post" },
+          { "name": "PATCH", "value": "patch" },
+          { "name": "DELETE", "value": "delete" }
+        ],
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "method"
+        }
+      },
+      {
+        "label": "Request Body",
+        "description": "Data to send to the endpoint.",
+        "value": "",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "body"
+        }
+      },
+      {
+        "label": "Result Variable",
+        "description": "Name of variable to store the response data in.",
+        "value": "response",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:output",
+          "source": "= body"
+        }
+      }
+    ]
+  },
+  {
+    "name": "foo",
+    "id": "io.camunda.foo",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "http",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "REST Endpoint URL",
+        "description": "Specify the url of the REST API to talk to.",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "url"
+        }
+      },
+      {
+        "label": "REST Method",
+        "description": "Specify the HTTP method to use.",
+        "type": "Dropdown",
+        "value": "get",
+        "choices": [
+          { "name": "GET", "value": "get" },
+          { "name": "POST", "value": "post" },
+          { "name": "PATCH", "value": "patch" },
+          { "name": "DELETE", "value": "delete" }
+        ],
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "method"
+        }
+      },
+      {
+        "label": "Request Body",
+        "description": "Data to send to the endpoint.",
+        "value": "",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "body"
+        }
+      },
+      {
+        "label": "Result Variable",
+        "description": "Name of variable to store the response data in.",
+        "value": "response",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:output",
+          "source": "= body"
+        }
+      }
+    ]
+  },
+  {
+    "name": "bar",
+    "id": "io.camunda.bar",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "http",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "REST Endpoint URL",
+        "description": "Specify the url of the REST API to talk to.",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "url"
+        }
+      },
+      {
+        "label": "Request Body",
+        "description": "Data to send to the endpoint.",
+        "value": "",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "body"
+        }
+      },
+      {
+        "label": "Result Variable",
+        "description": "Name of variable to store the response data in.",
+        "value": "response",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:output",
+          "source": "= body"
+        }
+      }
+    ]
+  }
+]

--- a/test/fixtures/multiple-connectors.json
+++ b/test/fixtures/multiple-connectors.json
@@ -1,0 +1,190 @@
+[
+  {
+    "name": "REST Connector",
+    "id": "io.camunda.connectors.RestConnector-s1",
+    "description": "A generic REST service.",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "http",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "REST Endpoint URL",
+        "description": "Specify the url of the REST API to talk to.",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "url"
+        },
+        "constraints": {
+          "notEmpty": true,
+          "pattern": {
+            "value": "^https?://.*",
+            "message": "Must be http(s) URL."
+          }
+        }
+      },
+      {
+        "label": "REST Method",
+        "description": "Specify the HTTP method to use.",
+        "type": "Dropdown",
+        "value": "get",
+        "choices": [
+          { "name": "GET", "value": "get" },
+          { "name": "POST", "value": "post" },
+          { "name": "PATCH", "value": "patch" },
+          { "name": "DELETE", "value": "delete" }
+        ],
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "method"
+        }
+      },
+      {
+        "label": "Request Body",
+        "description": "Data to send to the endpoint.",
+        "value": "",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "body"
+        }
+      },
+      {
+        "label": "Result Variable",
+        "description": "Name of variable to store the response data in.",
+        "value": "response",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:output",
+          "source": "= body"
+        }
+      }
+    ]
+  },
+  {
+    "name": "Rest Connector 2",
+    "id": "io.camunda.connectors.RestConnector-2",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "label": "REST Method",
+        "description": "Specify the HTTP method to use.",
+        "type": "Dropdown",
+        "value": "get",
+        "choices": [
+          { "name": "GET", "value": "get" },
+          { "name": "POST", "value": "post" },
+          { "name": "PATCH", "value": "patch" },
+          { "name": "DELETE", "value": "delete" }
+        ],
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "method"
+        }
+      },
+      {
+        "label": "Request Body",
+        "description": "Data to send to the endpoint.",
+        "value": "",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "body"
+        }
+      },
+      {
+        "label": "Result Variable",
+        "description": "Name of variable to store the response data in.",
+        "value": "response",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:output",
+          "source": "= body"
+        }
+      }
+    ]
+  },
+  {
+    "name": "foo",
+    "id": "io.camunda.foo",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "http",
+        "binding": {
+          "type": "zeebe:taskDefinition:type"
+        }
+      },
+      {
+        "label": "REST Endpoint URL",
+        "description": "Specify the url of the REST API to talk to.",
+        "type": "String",
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "url"
+        },
+        "constraints": {
+          "notEmpty": true,
+          "pattern": {
+            "value": "^https?://.*",
+            "message": "Must be http(s) URL."
+          }
+        }
+      },
+      {
+        "label": "REST Method",
+        "description": "Specify the HTTP method to use.",
+        "type": "Dropdown",
+        "value": "get",
+        "choices": [
+          { "name": "GET", "value": "get" },
+          { "name": "POST", "value": "post" },
+          { "name": "PATCH", "value": "patch" },
+          { "name": "DELETE", "value": "delete" }
+        ],
+        "binding": {
+          "type": "zeebe:taskHeader",
+          "key": "method"
+        }
+      },
+      {
+        "label": "Request Body",
+        "description": "Data to send to the endpoint.",
+        "value": "",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:input",
+          "name": "body"
+        }
+      },
+      {
+        "label": "Result Variable",
+        "description": "Name of variable to store the response data in.",
+        "value": "response",
+        "type": "String",
+        "optional": true,
+        "binding": {
+          "type": "zeebe:output",
+          "source": "= body"
+        }
+      }
+    ]
+  }
+]

--- a/test/fixtures/rest-connector-broken.json
+++ b/test/fixtures/rest-connector-broken.json
@@ -1,0 +1,67 @@
+{
+  "name": "REST Connector",
+  "id": "io.camunda.connectors.RestConnector-s1",
+  "description": "A generic REST service.",
+  "appliesTo": [
+    "bpmn:ServiceTask"
+  ],
+  "properties": [
+    {
+      "type": "Hidden",
+      "value": "http",
+      "binding": {
+        "type": "zeebe:taskDefinition:foo"
+      }
+    },
+    {
+      "label": "REST Endpoint URL",
+      "description": "Specify the url of the REST API to talk to.",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:taskHeader"
+      },
+      "constraints": {
+        "notEmpty": true,
+        "pattern": {
+          "value": "^https?://.*",
+          "message": "Must be http(s) URL."
+        }
+      }
+    },
+    {
+      "label": "REST Method",
+      "description": "Specify the HTTP method to use.",
+      "type": "Dropdown",
+      "value": "get",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "method"
+      }
+    },
+    {
+      "label": "Request Body",
+      "description": "Data to send to the endpoint.",
+      "value": "",
+      "type": "String",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:input",
+        "name": "body"
+      }
+    },
+    {
+      "label": "Result Variable",
+      "description": "Name of variable to store the response data in.",
+      "value": "response",
+      "type": "String",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:output",
+        "source": "= body"
+      },
+      "constraints": {
+        "notEmpty": true
+      }
+    }
+  ]
+}

--- a/test/fixtures/rest-connector.json
+++ b/test/fixtures/rest-connector.json
@@ -1,0 +1,71 @@
+{
+  "name": "REST Connector",
+  "id": "io.camunda.connectors.RestConnector-s1",
+  "description": "A generic REST service.",
+  "appliesTo": [
+    "bpmn:ServiceTask"
+  ],
+  "properties": [
+    {
+      "type": "Hidden",
+      "value": "http",
+      "binding": {
+        "type": "zeebe:taskDefinition:type"
+      }
+    },
+    {
+      "label": "REST Endpoint URL",
+      "description": "Specify the url of the REST API to talk to.",
+      "type": "String",
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "url"
+      },
+      "constraints": {
+        "notEmpty": true,
+        "pattern": {
+          "value": "^https?://.*",
+          "message": "Must be http(s) URL."
+        }
+      }
+    },
+    {
+      "label": "REST Method",
+      "description": "Specify the HTTP method to use.",
+      "type": "Dropdown",
+      "value": "get",
+      "choices": [
+        { "name": "GET", "value": "get" },
+        { "name": "POST", "value": "post" },
+        { "name": "PATCH", "value": "patch" },
+        { "name": "DELETE", "value": "delete" }
+      ],
+      "binding": {
+        "type": "zeebe:taskHeader",
+        "key": "method"
+      }
+    },
+    {
+      "label": "Request Body",
+      "description": "Data to send to the endpoint.",
+      "value": "",
+      "type": "String",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:input",
+        "name": "body"
+      }
+    },
+    {
+      "label": "Result Variable",
+      "description": "Name of variable to store the response data in.",
+      "value": "response",
+      "type": "String",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:output",
+        "source": "= body"
+      }
+    }
+  ]
+}

--- a/test/spec/validationSpec.js
+++ b/test/spec/validationSpec.js
@@ -3,9 +3,11 @@ import { expect } from 'chai';
 import { map, keys } from 'min-dash';
 
 import {
+  getSchemaPackage,
   getSchemaVersion,
   validate,
   validateAll,
+  getZeebeSchemaPackage,
   getZeebeSchemaVersion,
   validateZeebe,
   validateAllZeebe
@@ -13,6 +15,17 @@ import {
 
 
 describe('Validator', function() {
+
+
+  describe('#getSchemaPackage', function() {
+
+    it('should return schema package', function() {
+
+      // then
+      expect(getSchemaPackage()).to.eql(
+        require('@camunda/element-templates-json-schema/package.json').name);
+    });
+  });
 
 
   describe('#getSchemaVersion', function() {
@@ -160,6 +173,17 @@ describe('Validator', function() {
       ]);
     });
 
+  });
+
+
+  describe('#getZeebeSchemaPackage', function() {
+
+    it('should return schema package', function() {
+
+      // then
+      expect(getZeebeSchemaPackage()).to.eql(
+        require('@camunda/zeebe-element-templates-json-schema/package.json').name);
+    });
   });
 
 


### PR DESCRIPTION
Closes #5 
Requires https://github.com/camunda/element-templates-json-schema/pull/43 to be merged and integrated.
Extends API to validate C8 element templates. In particular, it adds the following exports

* `getSchemaPackage`
* `validateZeebe`
* `validateAllZeebe`
* `getZeebeSchemaVersion` 
* `getZeebeSchemaPackage`

```js
import { validateZeebe } from '@bpmn-io/element-templates-validator/zeebe';

import sample from './test/fixtures/rest-connector-broken.json';

const {
  valid,
  errors
} = validateZeebe(sample);

if (!valid) {
  console.error('Invalid JSON detected:', errors);
}
```

-----

Note: I considered exporting these APIs differently, e.g. 

```js
import { validate } from '@bpmn-io/element-templates-validator/zeebe`
```

but found that simply adding the new methods on top might be more intuitive, also causing less build configuration. 