### PR TITLE
chore: add error messages

### DIFF
--- a/lib/helper/withErrors.js
+++ b/lib/helper/withErrors.js
@@ -1,0 +1,32 @@
+import { forEach, set } from 'min-dash';
+
+export default function withErrorMessages(schema, errors) {
+
+  if (!errors || !errors.length) {
+    return schema;
+  }
+
+  // clone a new copy
+  let newSchema = JSON.parse(JSON.stringify(schema));
+
+  // set <errorMessage> keyword for given path
+  forEach(errors, function(error) {
+    newSchema = setErrorMessage(newSchema, error);
+  });
+
+  return newSchema;
+}
+
+function setErrorMessage(schema, error) {
+  const {
+    path,
+    errorMessage
+  } = error;
+
+  const errorMessagePath = [
+    ...path,
+    'errorMessage'
+  ];
+
+  return set(schema, errorMessagePath, errorMessage);
+}

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,8 +1,11 @@
 import createAjvInstance from './helper/createAjvInstance';
 
+import withErrorMessages from './helper/withErrors';
+
 import schema from '@camunda/element-templates-json-schema/resources/schema.json';
+import errorMessages from '@camunda/element-templates-json-schema/resources/error-messages.json';
 
 const ajvInstance = createAjvInstance();
 
-export default ajvInstance.compile(schema);
+export default ajvInstance.compile(withErrorMessages(schema, errorMessages));
 export const ajv = ajvInstance;

--- a/lib/validateZeebe.js
+++ b/lib/validateZeebe.js
@@ -1,8 +1,11 @@
 import createAjvInstance from './helper/createAjvInstance';
 
+import withErrorMessages from './helper/withErrors';
+
 import schema from '@camunda/zeebe-element-templates-json-schema/resources/schema.json';
+import errorMessages from '@camunda/zeebe-element-templates-json-schema/resources/error-messages.json';
 
 const ajvInstance = createAjvInstance();
 
-export default ajvInstance.compile(schema);
+export default ajvInstance.compile(withErrorMessages(schema, errorMessages));
 export const ajv = ajvInstance;

--- a/package-lock.json
+++ b/package-lock.json
@@ -193,14 +193,14 @@
       }
     },
     "@camunda/element-templates-json-schema": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.9.1.tgz",
-      "integrity": "sha512-hqAOdwf0EdEDughDAfsOWtQQaKx/7m3srVbrUfVZy2Nh2mUc3hyBbkODO4tkMjTKv6I4bw36cyMchzjIEaz4CA=="
+      "version": "0.10.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.10.0-alpha.1.tgz",
+      "integrity": "sha512-QmgwXEwr1iMpF+SJl40cWF/V7d8mUhjsT+bqkAooC+o/fC5/57vK70doJOEwBw7sgFblbvdo7O9vf7aemz9PnA=="
     },
     "@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.4.1.tgz",
-      "integrity": "sha512-FAe7auxm+IJiRB0W68VOjBxih6aOJB/0K3nvjO0TtRdyS+a2X1DIDBDtsQO6g+pJDtW6oij0kC1LiBUvm6FmLw=="
+      "version": "0.5.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.5.0-alpha.1.tgz",
+      "integrity": "sha512-d3Va5dHIH0AY4uWsgkWCUZ1ENOiiVbHIZYaEqu2effb/ATmwEIyPMfhTUzlNPjP4z0NG2dvGLIbBMgK1nQqMiA=="
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3598,8 +3598,7 @@
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "resolved": "",
           "dev": true
         },
         "is-fullwidth-code-point": {

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "rollup": "^2.66.1"
   },
   "dependencies": {
-    "@camunda/element-templates-json-schema": "^0.9.1",
-    "@camunda/zeebe-element-templates-json-schema": "^0.4.1",
+    "@camunda/element-templates-json-schema": "^0.10.0-alpha.1",
+    "@camunda/zeebe-element-templates-json-schema": "^0.5.0-alpha.1",
     "json-source-map": "^0.6.1",
     "min-dash": "^3.8.1"
   }


### PR DESCRIPTION
Depends on https://github.com/camunda/element-templates-json-schema/pull/57

* Bumps to the latest alpha versions of the schemas
* Merges `error-message` definitions into the schema before the Validator got created