### PR TITLE
chore(build): create standalone validator during install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@bpmn-io/element-templates-validator",
       "version": "0.12.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@camunda/element-templates-json-schema": "^0.11.0",
@@ -15,10 +16,8 @@
         "min-dash": "^4.0.0"
       },
       "devDependencies": {
-        "@rollup/plugin-alias": "^3.1.9",
         "@rollup/plugin-commonjs": "^22.0.2",
         "@rollup/plugin-json": "^4.1.0",
-        "@rollup/plugin-node-resolve": "^14.1.0",
         "ajv": "^7.2.4",
         "ajv-errors": "^2.0.1",
         "chai": "^4.3.6",
@@ -175,21 +174,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@rollup/plugin-alias": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.9.tgz",
-      "integrity": "sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==",
-      "dev": true,
-      "dependencies": {
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0"
-      }
-    },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "22.0.2",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-22.0.2.tgz",
@@ -223,39 +207,6 @@
         "rollup": "^1.20.0 || ^2.0.0"
       }
     },
-    "node_modules/@rollup/plugin-node-resolve": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-14.1.0.tgz",
-      "integrity": "sha512-5G2niJroNCz/1zqwXtk0t9+twOSDlG00k1Wfd7bkbbXmwg8H8dvgHdIWAun53Ps/rckfvOC7scDBjuGFg5OaWw==",
-      "dev": true,
-      "dependencies": {
-        "@rollup/pluginutils": "^3.1.0",
-        "@types/resolve": "1.17.1",
-        "deepmerge": "^4.2.2",
-        "is-builtin-module": "^3.1.0",
-        "is-module": "^1.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^2.78.0"
-      }
-    },
-    "node_modules/@rollup/plugin-node-resolve/node_modules/resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/@rollup/pluginutils": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
@@ -284,21 +235,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
-    },
-    "node_modules/@types/node": {
-      "version": "16.10.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.3.tgz",
-      "integrity": "sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ==",
-      "dev": true
-    },
-    "node_modules/@types/resolve": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
-      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -498,18 +434,6 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
-    },
-    "node_modules/builtin-modules": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
-      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -761,15 +685,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
-    },
-    "node_modules/deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/define-properties": {
       "version": "1.1.4",
@@ -1755,21 +1670,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-builtin-module": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
-      "integrity": "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
-      "dev": true,
-      "dependencies": {
-        "builtin-modules": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -1838,12 +1738,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
-      "dev": true
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
@@ -3652,15 +3546,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@rollup/plugin-alias": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.9.tgz",
-      "integrity": "sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==",
-      "dev": true,
-      "requires": {
-        "slash": "^3.0.0"
-      }
-    },
     "@rollup/plugin-commonjs": {
       "version": "22.0.2",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-22.0.2.tgz",
@@ -3683,32 +3568,6 @@
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.0.8"
-      }
-    },
-    "@rollup/plugin-node-resolve": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-14.1.0.tgz",
-      "integrity": "sha512-5G2niJroNCz/1zqwXtk0t9+twOSDlG00k1Wfd7bkbbXmwg8H8dvgHdIWAun53Ps/rckfvOC7scDBjuGFg5OaWw==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^3.1.0",
-        "@types/resolve": "1.17.1",
-        "deepmerge": "^4.2.2",
-        "is-builtin-module": "^3.1.0",
-        "is-module": "^1.0.0",
-        "resolve": "^1.19.0"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.20.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
-          }
-        }
       }
     },
     "@rollup/pluginutils": {
@@ -3735,21 +3594,6 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
-    },
-    "@types/node": {
-      "version": "16.10.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.3.tgz",
-      "integrity": "sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ==",
-      "dev": true
-    },
-    "@types/resolve": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
-      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -3898,12 +3742,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
-    },
-    "builtin-modules": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
-      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
       "dev": true
     },
     "call-bind": {
@@ -4093,12 +3931,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
-    },
-    "deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
     },
     "define-properties": {
@@ -4836,15 +4668,6 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-builtin-module": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.0.tgz",
-      "integrity": "sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "^3.3.0"
-      }
-    },
     "is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -4889,12 +4712,6 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
-    },
-    "is-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
-      "dev": true
     },
     "is-negative-zero": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,12 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@camunda/element-templates-json-schema": "^0.11.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.7.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.0.0"
       },
       "devDependencies": {
+        "@camunda/element-templates-json-schema": "^0.11.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.7.0",
         "@rollup/plugin-commonjs": "^22.0.2",
         "@rollup/plugin-json": "^4.1.0",
         "ajv": "^7.2.4",
@@ -27,17 +27,23 @@
         "mocha": "^8.4.0",
         "npm-run-all": "^4.1.5",
         "rollup": "^2.79.1"
+      },
+      "peerDependencies": {
+        "@camunda/element-templates-json-schema": "*",
+        "@camunda/zeebe-element-templates-json-schema": "*"
       }
     },
     "node_modules/@camunda/element-templates-json-schema": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.11.0.tgz",
-      "integrity": "sha512-5xZ7am4zoJmMGtgRuJExN9jPRXid0Z92AJCXfCKIL5MQmNrLQETGwZrd0hVfXZ5w8PqbuurtyMB5IXCxwfLDZQ=="
+      "integrity": "sha512-5xZ7am4zoJmMGtgRuJExN9jPRXid0Z92AJCXfCKIL5MQmNrLQETGwZrd0hVfXZ5w8PqbuurtyMB5IXCxwfLDZQ==",
+      "dev": true
     },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.7.0.tgz",
-      "integrity": "sha512-0u0lgeinz5Pc6wSaHHsUgYcMwu5dvNDiAOqMkGBcZWkDhMCmno7rQ2Isf9aLqEZixSJa3mjGlEABirwPvynXaA=="
+      "integrity": "sha512-0u0lgeinz5Pc6wSaHHsUgYcMwu5dvNDiAOqMkGBcZWkDhMCmno7rQ2Isf9aLqEZixSJa3mjGlEABirwPvynXaA==",
+      "dev": true
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.2",
@@ -3438,12 +3444,14 @@
     "@camunda/element-templates-json-schema": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.11.0.tgz",
-      "integrity": "sha512-5xZ7am4zoJmMGtgRuJExN9jPRXid0Z92AJCXfCKIL5MQmNrLQETGwZrd0hVfXZ5w8PqbuurtyMB5IXCxwfLDZQ=="
+      "integrity": "sha512-5xZ7am4zoJmMGtgRuJExN9jPRXid0Z92AJCXfCKIL5MQmNrLQETGwZrd0hVfXZ5w8PqbuurtyMB5IXCxwfLDZQ==",
+      "dev": true
     },
     "@camunda/zeebe-element-templates-json-schema": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.7.0.tgz",
-      "integrity": "sha512-0u0lgeinz5Pc6wSaHHsUgYcMwu5dvNDiAOqMkGBcZWkDhMCmno7rQ2Isf9aLqEZixSJa3mjGlEABirwPvynXaA=="
+      "integrity": "sha512-0u0lgeinz5Pc6wSaHHsUgYcMwu5dvNDiAOqMkGBcZWkDhMCmno7rQ2Isf9aLqEZixSJa3mjGlEABirwPvynXaA==",
+      "dev": true
     },
     "@eslint/eslintrc": {
       "version": "1.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,10 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@camunda/element-templates-json-schema": "^0.11.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.7.0",
+        "ajv": "^7.2.4",
+        "ajv-errors": "^2.0.1",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.0.0"
       },
@@ -18,8 +22,6 @@
         "@camunda/zeebe-element-templates-json-schema": "^0.7.0",
         "@rollup/plugin-commonjs": "^22.0.2",
         "@rollup/plugin-json": "^4.1.0",
-        "ajv": "^7.2.4",
-        "ajv-errors": "^2.0.1",
         "chai": "^4.3.6",
         "eslint": "^8.24.0",
         "eslint-plugin-bpmn-io": "^0.16.0",
@@ -27,10 +29,6 @@
         "mocha": "^8.4.0",
         "npm-run-all": "^4.1.5",
         "rollup": "^2.79.1"
-      },
-      "peerDependencies": {
-        "@camunda/element-templates-json-schema": "*",
-        "@camunda/zeebe-element-templates-json-schema": "*"
       }
     },
     "node_modules/@camunda/element-templates-json-schema": {
@@ -273,7 +271,6 @@
       "version": "7.2.4",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
       "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
-      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -289,7 +286,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-2.0.1.tgz",
       "integrity": "sha512-hGH2npS6nUdBr61gf3rcG8R04DwwgQsdt6goZGmaZHYRHtLF948Emsdta/bcP9AD6/X1jnHm9lMbgujOQG7W6A==",
-      "dev": true,
       "peerDependencies": {
         "ajv": "^7.0.0"
       }
@@ -1185,8 +1181,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -1908,8 +1903,7 @@
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/json-source-map": {
       "version": "0.6.1",
@@ -2659,7 +2653,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2773,7 +2766,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3207,7 +3199,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -3626,7 +3617,6 @@
       "version": "7.2.4",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.2.4.tgz",
       "integrity": "sha512-nBeQgg/ZZA3u3SYxyaDvpvDtgZ/EZPF547ARgZBrG9Bhu1vKDwAIjtIf+sDtJUKa2zOcEbmRLBRSyMraS/Oy1A==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -3638,7 +3628,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-2.0.1.tgz",
       "integrity": "sha512-hGH2npS6nUdBr61gf3rcG8R04DwwgQsdt6goZGmaZHYRHtLF948Emsdta/bcP9AD6/X1jnHm9lMbgujOQG7W6A==",
-      "dev": true,
       "requires": {}
     },
     "ansi-colors": {
@@ -4315,8 +4304,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-glob": {
       "version": "3.2.12",
@@ -4839,8 +4827,7 @@
     "json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "json-source-map": {
       "version": "0.6.1",
@@ -5399,8 +5386,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -5475,8 +5461,7 @@
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "resolve": {
       "version": "1.18.1",
@@ -5782,7 +5767,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
   },
   "homepage": "https://github.com/bpmn-io/element-templates-validator#readme",
   "devDependencies": {
+    "@camunda/element-templates-json-schema": "^0.11.0",
+    "@camunda/zeebe-element-templates-json-schema": "^0.7.0",
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-json": "^4.1.0",
     "ajv": "^7.2.4",
@@ -54,9 +56,11 @@
     "rollup": "^2.79.1"
   },
   "dependencies": {
-    "@camunda/element-templates-json-schema": "^0.11.0",
-    "@camunda/zeebe-element-templates-json-schema": "^0.7.0",
     "json-source-map": "^0.6.1",
     "min-dash": "^4.0.0"
+  },
+  "peerDependencies": {
+    "@camunda/element-templates-json-schema": "*",
+    "@camunda/zeebe-element-templates-json-schema": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,13 +6,15 @@
   "module": "dist/index.esm.js",
   "source": "lib/index.js",
   "files": [
-    "dist"
+    "dist",
+    "tasks"
   ],
   "scripts": {
     "build": "rollup -c",
     "distro": "run-s build test:build",
     "lint": "eslint .",
     "prepublishOnly": "run-s distro",
+    "postinstall": "node tasks/createStandaloneValidator",
     "test": "mocha -r esm --reporter=spec --recursive test/spec",
     "test:build": "mocha --reporter=spec --recursive test/distro",
     "all": "run-s lint build test distro"
@@ -39,10 +41,8 @@
   },
   "homepage": "https://github.com/bpmn-io/element-templates-validator#readme",
   "devDependencies": {
-    "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-json": "^4.1.0",
-    "@rollup/plugin-node-resolve": "^14.1.0",
     "ajv": "^7.2.4",
     "ajv-errors": "^2.0.1",
     "chai": "^4.3.6",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,6 @@
     "@camunda/zeebe-element-templates-json-schema": "^0.7.0",
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-json": "^4.1.0",
-    "ajv": "^7.2.4",
-    "ajv-errors": "^2.0.1",
     "chai": "^4.3.6",
     "eslint": "^8.24.0",
     "eslint-plugin-bpmn-io": "^0.16.0",
@@ -58,11 +56,11 @@
     "rollup": "^2.79.1"
   },
   "dependencies": {
+    "@camunda/element-templates-json-schema": "^0.11.0",
+    "@camunda/zeebe-element-templates-json-schema": "^0.7.0",
+    "ajv": "^7.2.4",
+    "ajv-errors": "^2.0.1",
     "json-source-map": "^0.6.1",
     "min-dash": "^4.0.0"
-  },
-  "peerDependencies": {
-    "@camunda/element-templates-json-schema": "*",
-    "@camunda/zeebe-element-templates-json-schema": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "tasks"
   ],
   "scripts": {
-    "build": "rollup -c",
+    "build": "run-s build:distro build:standalone",
+    "build:distro": "rollup -c",
+    "build:standalone": "node tasks/createStandaloneValidator",
     "distro": "run-s build test:build",
     "lint": "eslint .",
     "prepublishOnly": "run-s distro",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -26,7 +26,7 @@ export default [
   {
     input: 'lib/validate.js',
     output: [
-      { file: 'dist/validate.js', format: 'cjs' }
+      { file: 'dist/raw/validate.js', format: 'cjs' }
     ],
     plugins: [
       json(),
@@ -36,7 +36,7 @@ export default [
   {
     input: 'lib/validateZeebe.js',
     output: [
-      { file: 'dist/validateZeebe.js', format: 'cjs' }
+      { file: 'dist/raw/validateZeebe.js', format: 'cjs' }
     ],
     plugins: [
       json(),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,13 +1,7 @@
 import json from '@rollup/plugin-json';
-import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
-import alias from '@rollup/plugin-alias';
 
 import pkg from './package.json';
-import {
-  createStandaloneValidator,
-  createStandaloneZeebeValidator
-} from './tasks/createStandaloneValidator.js';
 
 
 const srcEntry = pkg.source;
@@ -20,17 +14,32 @@ export default [
       { file: pkg.module, format: 'es' }
     ],
     external: [
-      'min-dash'
+      'min-dash',
+      './validate',
+      './validateZeebe'
     ],
     plugins: [
-      alias({
-        entries: {
-          './validate': createStandaloneValidator(),
-          './validateZeebe': createStandaloneZeebeValidator()
-        }
-      }),
       json(),
-      nodeResolve(),
+      commonjs()
+    ]
+  },
+  {
+    input: 'lib/validate.js',
+    output: [
+      { file: 'dist/validate.js', format: 'cjs' }
+    ],
+    plugins: [
+      json(),
+      commonjs()
+    ]
+  },
+  {
+    input: 'lib/validateZeebe.js',
+    output: [
+      { file: 'dist/validateZeebe.js', format: 'cjs' }
+    ],
+    plugins: [
+      json(),
       commonjs()
     ]
   }

--- a/tasks/createStandaloneValidator.js
+++ b/tasks/createStandaloneValidator.js
@@ -7,17 +7,24 @@ const { writeFileSync: writeFile, mkdirSync: mkdir } = fs;
 
 (function() {
 
+  // dist not built yet
   if (!fs.existsSync('dist/')) {
-    console.log('build script has not run yet, exiting ...');
     return;
   }
 
-  const { default: validate, ajv } = require('../dist/validate');
-  const { default: validateZeebe, ajv: zeebeAjv } = require('../dist/validateZeebe');
+  const validate = require('../dist/validate');
+  const validateZeebe = require('../dist/validateZeebe');
 
+  const ajv = validate.ajv;
+  const zeebeAjv = validateZeebe.ajv;
+
+  // already standalone
+  if (!ajv || !zeebeAjv) {
+    return;
+  }
 
   function createStandaloneValidator() {
-    const code = standaloneCode(ajv, validate);
+    const code = standaloneCode(ajv, validate.default);
     const filePath = pathJoin('dist', 'validate.js');
 
     try {
@@ -26,14 +33,13 @@ const { writeFileSync: writeFile, mkdirSync: mkdir } = fs;
 
     // ignore; directory may already exist
     }
-
     writeFile(filePath, code);
 
     return filePath;
   }
 
   function createStandaloneZeebeValidator() {
-    const code = standaloneCode(zeebeAjv, validateZeebe);
+    const code = standaloneCode(zeebeAjv, validateZeebe.default);
     const filePath = pathJoin('dist', 'validateZeebe.js');
 
     try {

--- a/tasks/createStandaloneValidator.js
+++ b/tasks/createStandaloneValidator.js
@@ -1,40 +1,53 @@
-import standaloneCode from 'ajv/dist/standalone';
-import { writeFileSync as writeFile, mkdirSync as mkdir } from 'fs';
-import { join as pathJoin, dirname } from 'path';
+/* eslint-env node */
+const fs = require('fs');
+const { default: standaloneCode } = require('ajv/dist/standalone');
+const { join : pathJoin, dirname } = require('path');
 
-import validate, { ajv } from '../lib/validate';
+const { writeFileSync: writeFile, mkdirSync: mkdir } = fs;
 
-import validateZeebe, { ajv as zeebeAjv } from '../lib/validateZeebe';
+(function() {
 
-
-export function createStandaloneValidator() {
-  const code = standaloneCode(ajv, validate);
-  const filePath = pathJoin('tmp', 'standaloneValidator.js');
-
-  try {
-    mkdir(dirname(filePath));
-  } catch (err) {
-
-    // ignore; directory may already exist
+  if (!fs.existsSync('dist/')) {
+    console.log('build script has not run yet, exiting ...');
+    return;
   }
 
-  writeFile(filePath, code);
+  const { default: validate, ajv } = require('../dist/validate');
+  const { default: validateZeebe, ajv: zeebeAjv } = require('../dist/validateZeebe');
 
-  return filePath;
-}
 
-export function createStandaloneZeebeValidator() {
-  const code = standaloneCode(zeebeAjv, validateZeebe);
-  const filePath = pathJoin('tmp', 'standaloneZeebeValidator.js');
+  function createStandaloneValidator() {
+    const code = standaloneCode(ajv, validate);
+    const filePath = pathJoin('dist', 'validate.js');
 
-  try {
-    mkdir(dirname(filePath));
-  } catch (err) {
+    try {
+      mkdir(dirname(filePath));
+    } catch (err) {
 
     // ignore; directory may already exist
+    }
+
+    writeFile(filePath, code);
+
+    return filePath;
   }
 
-  writeFile(filePath, code);
+  function createStandaloneZeebeValidator() {
+    const code = standaloneCode(zeebeAjv, validateZeebe);
+    const filePath = pathJoin('dist', 'validateZeebe.js');
 
-  return filePath;
-}
+    try {
+      mkdir(dirname(filePath));
+    } catch (err) {
+
+    // ignore; directory may already exist
+    }
+
+    writeFile(filePath, code);
+
+    return filePath;
+  }
+
+  createStandaloneValidator();
+  createStandaloneZeebeValidator();
+})();

--- a/tasks/createStandaloneValidator.js
+++ b/tasks/createStandaloneValidator.js
@@ -8,20 +8,15 @@ const { writeFileSync: writeFile, mkdirSync: mkdir } = fs;
 (function() {
 
   // dist not built yet
-  if (!fs.existsSync('dist/')) {
+  if (!fs.existsSync('dist/raw')) {
     return;
   }
 
-  const validate = require('../dist/validate');
-  const validateZeebe = require('../dist/validateZeebe');
+  const validate = require('../dist/raw/validate');
+  const validateZeebe = require('../dist/raw/validateZeebe');
 
   const ajv = validate.ajv;
   const zeebeAjv = validateZeebe.ajv;
-
-  // already standalone
-  if (!ajv || !zeebeAjv) {
-    return;
-  }
 
   function createStandaloneValidator() {
     const code = standaloneCode(ajv, validate.default);


### PR DESCRIPTION
- published files will be bundled but not standalone
- standalone validator is created in `postinstall` script, using the schema version available to npm

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
