### PR TITLE
feat: support  `zeebe:formDefinition`, `zeebe:calledDecision`, `bpmn:ScriptTask` with `zeebe:script` and `zeebe:taskDefinition`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@camunda/element-templates-json-schema": "^0.19.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.23.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.24.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^4.1.1"
       },
@@ -37,10 +37,9 @@
       "license": "MIT"
     },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.23.0.tgz",
-      "integrity": "sha512-YC3q1xaZAC5dpdKFC9/7QNEfguegogb6DnDUjINQixt9xpFTbtAgtR3o2bv286XhndiFEhQpYO0gWTmPmXiqOA==",
-      "license": "MIT"
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.24.0.tgz",
+      "integrity": "sha512-TUfZ6zXtNjM/468mu6I0qOq4GSN579en2Bpncj7yv4mwwhibaJ4ieYpgw/YN/Iw9F+w5/cCPwfqtNuhPSE1SpA=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -4157,9 +4156,9 @@
       "integrity": "sha512-KzINxW6J79ZN1N6aLMmeVv/RmY9yq28sQloWTzkz6x9oiZY2PnfM8SUHUKWctXbVM/SZY3jdPSngFZeg1++v6A=="
     },
     "@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.23.0.tgz",
-      "integrity": "sha512-YC3q1xaZAC5dpdKFC9/7QNEfguegogb6DnDUjINQixt9xpFTbtAgtR3o2bv286XhndiFEhQpYO0gWTmPmXiqOA=="
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.24.0.tgz",
+      "integrity": "sha512-TUfZ6zXtNjM/468mu6I0qOq4GSN579en2Bpncj7yv4mwwhibaJ4ieYpgw/YN/Iw9F+w5/cCPwfqtNuhPSE1SpA=="
     },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@camunda/element-templates-json-schema": "^0.19.0",
-    "@camunda/zeebe-element-templates-json-schema": "^0.23.0",
+    "@camunda/zeebe-element-templates-json-schema": "^0.24.0",
     "json-source-map": "^0.6.1",
     "min-dash": "^4.1.1"
   }

--- a/test/fixtures/called-decision-broken.json
+++ b/test/fixtures/called-decision-broken.json
@@ -1,0 +1,145 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Called Decision with invalid property",
+    "id": "called-decision-invalid-property",
+    "description": "A reusable rule template",
+    "version": 1,
+    "engines": {
+      "camunda": "^8.6"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:BusinessRuleTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "aValue",
+        "binding": {
+          "type": "zeebe:calledDecision",
+          "property": "youShallNotPass"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Called Decision with incorrect type",
+    "id": "called-decision-invalid-element-type",
+    "description": "A reusable rule template",
+    "version": 1,
+    "engines": {
+      "camunda": "^8.6"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:Task"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "aReusableRule",
+        "binding": {
+          "type": "zeebe:calledDecision",
+          "property": "decisionId"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "aResultVariable",
+        "binding": {
+          "type": "zeebe:calledDecision",
+          "property": "resultVariable"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Called Decision with missing decisionId",
+    "id": "called-decision-missing-decisionId",
+    "description": "A reusable rule template",
+    "version": 1,
+    "engines": {
+      "camunda": "^8.6"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:BusinessRuleTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "aResultVariable",
+        "binding": {
+          "type": "zeebe:calledDecision",
+          "property": "resultVariable"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Called Decision with missing element type",
+    "id": "called-decision-missing-element-type",
+    "description": "A reusable rule template",
+    "version": 1,
+    "engines": {
+      "camunda": "^8.6"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "aReusableRule",
+        "binding": {
+          "type": "zeebe:calledDecision",
+          "property": "decisionId"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "aResultVariable",
+        "binding": {
+          "type": "zeebe:calledDecision",
+          "property": "resultVariable"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Called Decision with missing resultVariable",
+    "id": "called-decision-missing-resultVariable",
+    "description": "A reusable rule template",
+    "version": 1,
+    "engines": {
+      "camunda": "^8.6"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:BusinessRuleTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "aDecisionId",
+        "binding": {
+          "type": "zeebe:calledDecision",
+          "property": "decisionId"
+        }
+      }
+    ]
+  }
+]

--- a/test/fixtures/called-decision.json
+++ b/test/fixtures/called-decision.json
@@ -1,0 +1,37 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Reusable Rule Template",
+    "id": "io.camunda.examples.Decision",
+    "description": "A reusable rule template",
+    "version": 1,
+    "engines": {
+      "camunda": "^8.6"
+    },
+    "appliesTo": [
+      "bpmn:Task",
+      "bpmn:BusinessRuleTask"
+    ],
+    "elementType": {
+      "value": "bpmn:BusinessRuleTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "aReusableRule",
+        "binding": {
+          "type": "zeebe:calledDecision",
+          "property": "decisionId"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "aResultVariable",
+        "binding": {
+          "type": "zeebe:calledDecision",
+          "property": "resultVariable"
+        }
+      }
+    ]
+  }
+]

--- a/test/fixtures/form-definition-broken.json
+++ b/test/fixtures/form-definition-broken.json
@@ -1,0 +1,77 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Reusable Rule Template",
+    "id": "sometemplate",
+    "description": "some description",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:UserTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "binding": {
+          "type": "zeebe:userTask"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "someReference",
+        "binding": {
+          "type": "zeebe:formDefinition",
+          "property": "invalidProperty"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Reusable Rule Template",
+    "id": "sometemplate",
+    "description": "some description",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:UserTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "someReference",
+        "binding": {
+          "type": "zeebe:formDefinition",
+          "property": "formId"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Reusable Rule Template",
+    "id": "sometemplate",
+    "description": "some description",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:UserTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "feel": "required",
+        "binding": {
+          "type": "zeebe:formDefinition",
+          "property": "formId"
+        }
+      }
+    ]
+  }
+]

--- a/test/fixtures/form-definition.json
+++ b/test/fixtures/form-definition.json
@@ -1,0 +1,62 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Reusable Rule Template",
+    "id": "sometemplate",
+    "description": "some description",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:UserTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "binding": {
+          "type": "zeebe:userTask"
+        }
+      },
+      {
+        "type": "String",
+        "value": "someReference",
+        "feel": "optional",
+        "binding": {
+          "type": "zeebe:formDefinition",
+          "property": "externalReference"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Reusable Rule Template",
+    "id": "sometemplate",
+    "description": "some description",
+    "version": 1,
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:UserTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "binding": {
+          "type": "zeebe:userTask"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "someReference",
+        "binding": {
+          "type": "zeebe:formDefinition",
+          "property": "formId"
+        }
+      }
+    ]
+  }
+
+]

--- a/test/fixtures/script-task-broken.json
+++ b/test/fixtures/script-task-broken.json
@@ -1,0 +1,145 @@
+[
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Script task with invalid property",
+    "id": "script-task-invalid-property",
+    "description": "A reusable script template",
+    "version": 1,
+    "engines": {
+      "camunda": "^8.6"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:ScriptTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "aValue",
+        "binding": {
+          "type": "zeebe:script",
+          "property": "youShallNotPass"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Script task with incorrect type",
+    "id": "script-task-invalid-element-type",
+    "description": "A reusable script template",
+    "version": 1,
+    "engines": {
+      "camunda": "^8.6"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:Task"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "=1 + 1",
+        "binding": {
+          "type": "zeebe:script",
+          "property": "expression"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "aResultVariable",
+        "binding": {
+          "type": "zeebe:script",
+          "property": "resultVariable"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Script task with missing expression",
+    "id": "script-task-missing-expression",
+    "description": "A reusable script template",
+    "version": 1,
+    "engines": {
+      "camunda": "^8.6"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:ScriptTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "aResultVariable",
+        "binding": {
+          "type": "zeebe:script",
+          "property": "resultVariable"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Script task with missing element type",
+    "id": "script-task-missing-element-type",
+    "description": "A reusable script template",
+    "version": 1,
+    "engines": {
+      "camunda": "^8.6"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "=1 + 1",
+        "binding": {
+          "type": "zeebe:script",
+          "property": "expression"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "aResultVariable",
+        "binding": {
+          "type": "zeebe:script",
+          "property": "resultVariable"
+        }
+      }
+    ]
+  },
+  {
+    "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+    "name": "Script task with missing resultVariable",
+    "id": "script-task-missing-resultVariable",
+    "description": "A reusable script template",
+    "version": 1,
+    "engines": {
+      "camunda": "^8.6"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:ScriptTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "=1 + 1",
+        "binding": {
+          "type": "zeebe:script",
+          "property": "expression"
+        }
+      }
+    ]
+  }
+]

--- a/test/fixtures/script-task-job-worker.json
+++ b/test/fixtures/script-task-job-worker.json
@@ -1,0 +1,35 @@
+[
+  {
+    "name": "Reusable Script Template",
+    "id": "io.camunda.examples.Script",
+    "description": "A reusable script template",
+    "version": 1,
+    "engines": {
+      "camunda": "^8.6"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:ScriptTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "my-job-worker",
+        "binding": {
+          "type": "zeebe:taskDefinition",
+          "property": "type"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "3",
+        "binding": {
+          "type": "zeebe:taskDefinition",
+          "property": "retries"
+        }
+      }
+    ]
+  }
+]

--- a/test/fixtures/script-task.json
+++ b/test/fixtures/script-task.json
@@ -1,0 +1,35 @@
+[
+  {
+    "name": "Reusable Script Template",
+    "id": "io.camunda.examples.Script",
+    "description": "A reusable script template",
+    "version": 1,
+    "engines": {
+      "camunda": "^8.6"
+    },
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:ScriptTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "=1 + 1",
+        "binding": {
+          "type": "zeebe:script",
+          "property": "expression"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "aResultVariable",
+        "binding": {
+          "type": "zeebe:script",
+          "property": "resultVariable"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/validationSpec.js
+++ b/test/spec/validationSpec.js
@@ -252,14 +252,14 @@ describe('Validator', function() {
           message: 'must provide choices=[] with "Dropdown" type'
         },
         {
-          message: 'invalid property.binding type "zeebe:taskDefinition:foo"; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource, zeebe:userTask }'
+          message: 'invalid property.binding type "zeebe:taskDefinition:foo"; must be any of { property, zeebe:taskDefinition:type, zeebe:input, zeebe:output, zeebe:property, zeebe:taskHeader, bpmn:Message#property, bpmn:Message#zeebe:subscription#property, zeebe:taskDefinition, zeebe:calledElement, zeebe:linkedResource, zeebe:userTask, zeebe:formDefinition, zeebe:calledDecision, zeebe:script }'
         },
         {
           message: 'property.binding "zeebe:taskHeader" requires key'
         },
         {
           message: 'must be string',
-          params : {
+          params: {
             type: 'string'
           }
         },
@@ -474,10 +474,145 @@ describe('Validator', function() {
       expect(results.map(r => r.object)).to.eql(samples);
     });
 
+
+    it('should validate form definition templates', function() {
+
+      // given
+      const samples = require('../fixtures/form-definition.json');
+
+      // when
+      const {
+        valid,
+        results
+      } = validateAllZeebe(samples);
+
+      // then
+      expect(valid).to.be.true;
+      expect(results.length).to.eql(samples.length);
+
+      expect(results.every(r => r.valid)).to.be.true;
+
+      expect(results.map(r => r.object)).to.eql(samples);
+    });
+
+
+    it('should validate form definition templates with errors', function() {
+
+      // given
+      const samples = require('../fixtures/form-definition-broken.json');
+
+      // when
+      const {
+        valid,
+        results
+      } = validateAllZeebe(samples);
+
+      // then
+      expect(valid).to.be.false;
+      expect(results.every(r => !r.valid)).to.be.true;
+      expect(results.map(r => r.object)).to.eql(samples);
+    });
+
+
+    it('should validate called decision templates', function() {
+
+      // given
+      const samples = require('../fixtures/called-decision.json');
+
+      // when
+      const {
+        valid,
+        results
+      } = validateAllZeebe(samples);
+
+      // then
+      expect(valid).to.be.true;
+      expect(results.length).to.eql(samples.length);
+
+      expect(results.every(r => r.valid)).to.be.true;
+
+      expect(results.map(r => r.object)).to.eql(samples);
+    });
+
+
+    it('should validate called decision templates with errors', function() {
+
+      // given
+      const samples = require('../fixtures/called-decision-broken.json');
+
+      // when
+      const {
+        valid,
+        results
+      } = validateAllZeebe(samples);
+
+      // then
+      expect(valid).to.be.false;
+      expect(results.every(r => !r.valid)).to.be.true;
+      expect(results.map(r => r.object)).to.eql(samples);
+    });
+
+
+    it('should validate script task templates', function() {
+
+      // given
+      const samples = require('../fixtures/script-task.json');
+
+      // when
+      const {
+        valid,
+        results
+      } = validateAllZeebe(samples);
+
+      // then
+      expect(valid).to.be.true;
+      expect(results.length).to.eql(samples.length);
+
+      expect(results.every(r => r.valid)).to.be.true;
+
+      expect(results.map(r => r.object)).to.eql(samples);
+    });
+
+
+    it('should validate script task templates with errors', function() {
+
+      // given
+      const samples = require('../fixtures/script-task-broken.json');
+
+      // when
+      const {
+        valid,
+        results
+      } = validateAllZeebe(samples);
+
+      // then
+      expect(valid).to.be.false;
+      expect(results.every(r => !r.valid)).to.be.true;
+      expect(results.map(r => r.object)).to.eql(samples);
+    });
+
+
+    it('should validate script task templates with job worker', function() {
+
+      // given
+      const samples = require('../fixtures/script-task-job-worker.json');
+
+      // when
+      const {
+        valid,
+        results
+      } = validateAllZeebe(samples);
+
+      // then
+      expect(valid).to.be.true;
+      expect(results.length).to.eql(samples.length);
+
+      expect(results.every(r => r.valid)).to.be.true;
+
+      expect(results.map(r => r.object)).to.eql(samples);
+    });
   });
-
 });
-
 
 // helper //////////////
 


### PR DESCRIPTION
### Proposed Changes

Add element template support for `zeebe:formDefinition`, `zeebe:calledDecision`, `bpmn:ScriptTask` with `zeebe:script` and `zeebe:taskDefinition`

Bumps schema version.

related to https://github.com/camunda/camunda-modeler/issues/5073
related to https://github.com/camunda/camunda-modeler/issues/5025
related to https://github.com/camunda/camunda-modeler/issues/5026

<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
