### PR TITLE
fix: introduce validateString and validateZeebeString to preserve format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [element-templates-validator](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+## 2.8.0
+
+* `FEAT`: `validateZeebe`, and `validate` support JSON strings preserving the original format ([#58](https://github.com/bpmn-io/element-templates-validator/issues/58))
+
 ## 2.7.0
 
 * `FEAT`: support `bindingType` for linking properties ([#60](https://github.com/bpmn-io/element-templates-validator/pull/60))

--- a/README.md
+++ b/README.md
@@ -59,7 +59,12 @@ This will print detailed information about errors inside the sample:
 ]
 ```
 
-It's also possible to validate multiple objects at once
+If you pass a JSON string to the `validateZeebe` and `validate` functions, the dataPointers of the errors will reflect the correct position in the original string.
+
+If a parsed JSON object is passed, the `dataPointers` may not match the original string.
+In this case, ensure to format your JSON before validating it, using the canonical format (e.g., with `JSON.stringify(sample, null, 2)`).
+
+It's also possible to validate multiple objects at once. In this case, the list of templates supports only objects, not strings.
 
 ```js
 import { validateAll } from '@bpmn-io/element-templates-validator';

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ const {
 if (!valid) {
   console.error('Invalid JSON detected:', errors);
 }
-
 ```
 
 This will print detailed information about errors inside the sample:
@@ -59,10 +58,26 @@ This will print detailed information about errors inside the sample:
 ]
 ```
 
-If you pass a JSON string to the `validateZeebe` and `validate` functions, the dataPointers of the errors will reflect the correct position in the original string.
+You can also pass a stringified template to ensure that the `dataPointers` of the errors reflect the correct position in the original string.
 
-If a parsed JSON object is passed, the `dataPointers` may not match the original string.
-In this case, ensure to format your JSON before validating it, using the canonical format (e.g., with `JSON.stringify(sample, null, 2)`).
+```js
+import { validate } from '@bpmn-io/element-templates-validator';
+
+import { readFileSync } from 'node:fs';
+
+const sample = readFileSync('./test/fixtures/rpa-broken.json', 'utf-8');
+
+const {
+  valid,
+  errors
+} = validate(sample);
+
+if (!valid) {
+  console.error('Invalid JSON detected:', errors);
+}
+```
+
+If a parsed JSON object is passed, the `dataPointers` will assume that the source template is formatted with `JSON.stringify(template, null, 2)`.
 
 It's also possible to validate multiple objects at once. In this case, the list of templates supports only objects, not strings.
 

--- a/lib/Validator.js
+++ b/lib/Validator.js
@@ -14,13 +14,17 @@ export function getSchemaPackage() {
 }
 
 /**
- * Validate a single object.
- *
- * @param {Object} object
- * @return {Object} single object validation result
+ * Validate a single template, which can be either a string or an object.
+ * If an **object** is passed, the data pointers assume double-space nesting, and empty lines will be discarded.
+ * @param {Object|string} template
+ * @return {Object} single template validation result
  */
-export function validate(object) {
-  return _validate(object, validateTemplate);
+export function validate(template) {
+  if (typeof template !== 'string') {
+    template = JSON.stringify(template, null, 2);
+  }
+
+  return _validate(template, validateTemplate);
 }
 
 /**

--- a/lib/ZeebeValidator.js
+++ b/lib/ZeebeValidator.js
@@ -14,13 +14,17 @@ export function getZeebeSchemaVersion() {
 }
 
 /**
- * Validate a single object.
- *
- * @param {Object} object
- * @return {Object} single object validation result
+ * Validate a single template, which can be either a string or an object.
+ * If an **object** is passed, the data pointers assume double-space nesting, and empty lines will be discarded.
+ * @param {Object|string} template
+ * @return {Object} single template validation result
  */
-export function validateZeebe(object) {
-  return _validate(object, validateTemplate);
+export function validateZeebe(template) {
+  if (typeof template !== 'string') {
+    template = JSON.stringify(template, null, 2);
+  }
+
+  return _validate(template, validateTemplate);
 }
 
 /**

--- a/lib/helper/validator.js
+++ b/lib/helper/validator.js
@@ -6,8 +6,22 @@ import {
 import jsonMap from 'json-source-map';
 
 
-export function _validate(object, validateFn) {
-  const dataPointerMap = generateDataPointerMap(object);
+export function _validate(jsonString, validateFn) {
+  let dataPointerMap;
+
+  try {
+    dataPointerMap = generateDataPointerMap(jsonString);
+  } catch (err) {
+    return {
+      valid: false,
+      object: null,
+      errors: [ err ]
+    };
+  }
+
+  let object;
+
+  object = JSON.parse(jsonString);
 
   const valid = validateFn(object);
 
@@ -87,7 +101,7 @@ function ignoreSupportiveErrors(errors) {
 }
 
 /**
- * Generates a key-pointer map for the object.
+ * Generates a key-pointer map for the JSON string.
  *
  * Example:
  *
@@ -110,9 +124,9 @@ function ignoreSupportiveErrors(errors) {
  *  }
  * }
  *
- * @param {Object} object
+ * @param {string} jsonString
  * @return {Object}
  */
-function generateDataPointerMap(object) {
-  return jsonMap.stringify(object, null, 2).pointers;
+function generateDataPointerMap(jsonString) {
+  return jsonMap.parse(jsonString).pointers;
 }

--- a/test/fixtures/unformatted-with-errors.json
+++ b/test/fixtures/unformatted-with-errors.json
@@ -1,0 +1,25 @@
+{
+        "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+        "name": "Reusable Rule Template",
+        "id": "io.camunda.examples.Decision",
+        "description": "A reusable rule template",
+        "version": 1,
+
+        "appliesTo": [
+            "bpmn:Task",
+            "bpmn:BusinessRuleTask"
+        ],
+
+        "elementType": {},
+
+        "properties": [
+            {
+                "type": "Hidden",
+                "value": "name",
+                "binding": {
+                    "type": "property",
+                    "name": "name"
+                }
+            }
+        ]
+}

--- a/test/fixtures/unformatted.json
+++ b/test/fixtures/unformatted.json
@@ -1,0 +1,23 @@
+{
+        "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+        "name": "Reusable Rule Template",
+        "id": "io.camunda.examples.Decision",
+        "description": "A reusable rule template",
+        "version": 1,
+
+        "appliesTo": [
+            "bpmn:Task",
+            "bpmn:BusinessRuleTask"
+        ],
+
+        "properties": [
+            {
+                "type": "Hidden",
+                "value": "name",
+                "binding": {
+                    "type": "property",
+                    "name": "name"
+                }
+            }
+        ]
+}

--- a/test/spec/validationSpec.js
+++ b/test/spec/validationSpec.js
@@ -2,6 +2,8 @@ import { expect } from 'chai';
 
 import { map, keys } from 'min-dash';
 
+import { readFileSync } from 'node:fs';
+
 import {
   getSchemaPackage,
   getSchemaVersion,
@@ -59,7 +61,7 @@ describe('Validator', function() {
 
       // then
       expect(valid).to.be.true;
-      expect(object).to.equal(sample);
+      expect(object).to.eql(sample);
       expect(errors).not.to.exist;
     });
 
@@ -80,7 +82,7 @@ describe('Validator', function() {
 
       // then
       expect(valid).to.be.false;
-      expect(object).to.equal(sample);
+      expect(object).to.eql(sample);
 
       expect(normalizedErrors).to.eql([
         { message: 'must be object', params: { type: 'object' } },
@@ -112,6 +114,86 @@ describe('Validator', function() {
       });
     });
 
+
+    describe('string input', function() {
+
+      it('should accept valid JSON string', function() {
+
+        // given
+        const sample = readFile('test/fixtures/unformatted.json');
+
+        // when
+        const {
+          errors,
+          object,
+          valid
+        } = validate(sample);
+
+        // then
+        expect(valid).to.be.true;
+        expect(object).to.exist;
+        expect(errors).to.not.exist;
+      });
+
+
+      it('should retrieve errors, and set data pointer according to the format', function() {
+
+        // given
+        const sample = readFile('test/fixtures/unformatted-with-errors.json');
+
+        // when
+        const {
+          errors,
+          valid
+        } = validate(sample);
+
+        // then
+        expect(valid).to.be.false;
+        expect(errors).to.exist;
+        expect(errors[0].dataPointer).to.eql({
+          'key': {
+            'line': 12,
+            'column': 8,
+            'pos': 375
+          },
+          'keyEnd': {
+            'line': 12,
+            'column': 21,
+            'pos': 388
+          },
+          'value': {
+            'line': 12,
+            'column': 23,
+            'pos': 390
+          },
+          'valueEnd': {
+            'line': 12,
+            'column': 25,
+            'pos': 392
+          }
+        });
+      });
+
+
+      it('should return an error for invalid JSON string', function() {
+
+        // given
+        const sample = '{ "foo": "bar" ';
+
+        // when
+        const {
+          errors,
+          object,
+          valid
+        } = validate(sample);
+
+        // then
+        expect(valid).to.be.false;
+        expect(object).to.be.null;
+        expect(errors).to.exist;
+        expect(errors[0].message).to.eql('Unexpected end of JSON input');
+      });
+    });
   });
 
 
@@ -221,7 +303,7 @@ describe('Validator', function() {
 
       // then
       expect(valid).to.be.true;
-      expect(object).to.equal(sample);
+      expect(object).to.eql(sample);
       expect(errors).not.to.exist;
     });
 
@@ -242,7 +324,7 @@ describe('Validator', function() {
 
       // then
       expect(valid).to.be.false;
-      expect(object).to.equal(sample);
+      expect(object).to.eql(sample);
 
       expect(normalizedErrors).to.eql([
         {
@@ -327,6 +409,87 @@ describe('Validator', function() {
         keyEnd: { line: 12, column: 14, pos: 273 },
         value: { line: 12, column: 16, pos: 275 },
         valueEnd: { line: 12, column: 42, pos: 301 }
+      });
+    });
+
+
+    describe('string input', function() {
+
+      it('should accept valid JSON string', function() {
+
+        // given
+        const sample = readFile('test/fixtures/unformatted.json');
+
+        // when
+        const {
+          errors,
+          object,
+          valid
+        } = validateZeebe(sample);
+
+        // then
+        expect(valid).to.be.true;
+        expect(object).to.exist;
+        expect(errors).to.not.exist;
+      });
+
+
+      it('should retrieve errors, and set data pointer according to the format', function() {
+
+        // given
+        const sample = readFile('test/fixtures/unformatted-with-errors.json');
+
+        // when
+        const {
+          errors,
+          valid
+        } = validateZeebe(sample);
+
+        // then
+        expect(valid).to.be.false;
+        expect(errors).to.exist;
+        expect(errors[0].dataPointer).to.eql({
+          'key': {
+            'line': 12,
+            'column': 8,
+            'pos': 375
+          },
+          'keyEnd': {
+            'line': 12,
+            'column': 21,
+            'pos': 388
+          },
+          'value': {
+            'line': 12,
+            'column': 23,
+            'pos': 390
+          },
+          'valueEnd': {
+            'line': 12,
+            'column': 25,
+            'pos': 392
+          }
+        });
+      });
+
+
+      it('should return an error for invalid JSON string', function() {
+
+        // given
+        const sample = '{ "foo": "bar" ';
+
+        // when
+        const {
+          errors,
+          object,
+          valid
+        } = validateZeebe(sample);
+
+        // then
+        expect(valid).to.be.false;
+        expect(object).to.be.null;
+        expect(errors).to.exist;
+        expect(errors[0].message).to.eql('Unexpected end of JSON input');
       });
     });
   });
@@ -763,4 +926,8 @@ function normalizeErrors(errors) {
 
     return normalizedError;
   });
+}
+
+function readFile(path) {
+  return readFileSync(path, 'utf-8');
 }


### PR DESCRIPTION
### Proposed Changes

Closes #58 

Introduces two new functions that perform validation, preserving the initial format of the templates.

Without fix:

https://github.com/user-attachments/assets/67535884-3996-4d70-8fb4-7264bd71fd07

With fix:


https://github.com/user-attachments/assets/046363f0-4faa-4c48-bf90-315d48dc28c7


### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
