### PR TITLE
feat: add `zeebe:taskSchedule` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to [element-templates-validator](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: support `zeebe:taskSchedule` binding
+
 ## 2.10.0
 
 * `FEAT`: support `zeebe:priorityDefinition` binding ([#64](https://github.com/bpmn-io/element-templates-validator/pull/64))

--- a/test/fixtures/task-schedule-broken.json
+++ b/test/fixtures/task-schedule-broken.json
@@ -1,0 +1,38 @@
+[
+  [
+    {
+      "name": "task schedule",
+      "id": "task-schedule-1",
+      "appliesTo": [
+        "bpmn:Task"
+      ],
+      "elementType": {
+        "value": "bpmn:UserTask"
+      },
+      "properties": [
+        {
+          "type": "Hidden",
+          "binding": {
+            "type": "zeebe:userTask"
+          }
+        },
+        {
+          "type": "String",
+          "value": "tomorrow",
+          "binding": {
+            "type": "zeebe:taskSchedule",
+            "property": "dueDate"
+          }
+        },
+        {
+          "type": "String",
+          "value": "2020/10/01T12:00:00Z",
+          "binding": {
+            "type": "zeebe:taskSchedule",
+            "property": "followUpDate"
+          }
+        }
+      ]
+    }
+  ]
+]

--- a/test/fixtures/task-schedule.json
+++ b/test/fixtures/task-schedule.json
@@ -1,0 +1,97 @@
+[
+  {
+    "name": "task schedule",
+    "id": "task-schedule-1",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:UserTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "binding": {
+          "type": "zeebe:userTask"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "2019-10-01T12:00:00Z",
+        "binding": {
+          "type": "zeebe:taskSchedule",
+          "property": "dueDate"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "2019-10-02T08:09:40+02:00",
+        "binding": {
+          "type": "zeebe:taskSchedule",
+          "property": "followUpDate"
+        }
+      }
+    ]
+  },
+  {
+    "name": "task schedule",
+    "id": "task-schedule-2",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:UserTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "binding": {
+          "type": "zeebe:userTask"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "2019-10-02T08:09:40+02:00[Europe/Berlin]",
+        "binding": {
+          "type": "zeebe:taskSchedule",
+          "property": "followUpDate"
+        }
+      }
+    ]
+  },
+  {
+    "name": "task schedule",
+    "id": "task-schedule-3",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "elementType": {
+      "value": "bpmn:UserTask"
+    },
+    "properties": [
+      {
+        "type": "Hidden",
+        "binding": {
+          "type": "zeebe:userTask"
+        }
+      },
+      {
+        "type": "Hidden",
+        "value": "2019-10-01T12:00:00Z",
+        "binding": {
+          "type": "zeebe:taskSchedule",
+          "property": "dueDate"
+        }
+      },
+      {
+        "type": "String",
+        "value": "2035-08-11T14:30:00-03:30",
+        "description": "Valid negative timezone offset with half-hour increment",
+        "binding": {
+          "type": "zeebe:taskSchedule",
+          "property": "dueDate"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/validationSpec.js
+++ b/test/spec/validationSpec.js
@@ -931,6 +931,44 @@ describe('Validator', function() {
       expect(results.map(r => r.object)).to.eql(samples);
     });
 
+    it('should validate taskSchedule templates', function() {
+
+      // given
+      const samples = require('../fixtures/task-schedule.json');
+
+      // when
+      const {
+        valid,
+        results
+      } = validateAllZeebe(samples);
+
+      // then
+      expect(valid).to.be.true;
+      expect(results.length).to.eql(samples.length);
+
+      expect(results.every(r => r.valid)).to.be.true;
+
+      expect(results.map(r => r.object)).to.eql(samples);
+    });
+
+
+    it('should validate taskSchedule templates with errors', function() {
+
+      // given
+      const samples = require('../fixtures/task-schedule-broken.json');
+
+      // when
+      const {
+        valid,
+        results
+      } = validateAllZeebe(samples);
+
+      // then
+      expect(valid).to.be.false;
+      expect(results.every(r => !r.valid)).to.be.true;
+      expect(results.map(r => r.object)).to.eql(samples);
+    });
+
 
     describe('property', function() {
 


### PR DESCRIPTION

### Proposed Changes

-  Element `zeebe:taskSchedule` can be templated
- Property `zeebe:taskSchedule#dueDate` can be templated
- Property `zeebe:taskSchedule#followUpDate` can be templated
- Both properties are String/Text typed with FEEL support or a Dropdown or Hidden. 
- the `value` set in the template for these properties can only be ISO 8601 date time
- `zeebe:taskSchedule` can only be set if `zeebe:UserTask` is set. 
- `zeebe:taskSchedule` can only exist in a `bpmn:UserTask`
- At least one of the properties needs to be set. 

related to https://github.com/camunda/camunda-modeler/issues/5093

### Checklist

To ensure you provided everything we need to look at your PR:

* [ ] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [ ] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
