### PR TITLE
Update json schema deps and prepare 2.20.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to [element-templates-validator](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+# 2.20.1
+
+* `FIX`: restrict usage of template-defined `zeebe:output` bindings when `entriesVisible.outputs === true` ([camunda/element-templates-json-schema#227](https://github.com/camunda/element-templates-json-schema/pull/227))
+* `DEPS`: update to `@camunda/zeebe-element-templates-json-schema@0.39.1`
+
 # 2.20.0
 
 * `FEAT`: add support for a custom deprecation message via `deprecationWarning` schema property ([#81](https://github.com/bpmn-io/element-templates-validator/pull/81))

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@camunda/element-templates-json-schema": "^0.21.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.39.0",
+        "@camunda/zeebe-element-templates-json-schema": "^0.39.1",
         "json-source-map": "^0.6.1",
         "min-dash": "^5.0.0"
       },
@@ -37,9 +37,9 @@
       "license": "MIT"
     },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.39.0.tgz",
-      "integrity": "sha512-+9X/Shf6q4DL3Il+vA1f4rwTbOMFTWYs0hdevtL1jAian4CS7lWyQdbACDZdBvNXPrHCvIrOMKDEzuasauiOQg==",
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.39.1.tgz",
+      "integrity": "sha512-JmBsoSX25hsRyYCTei851dkI6zmQnGxi9TrmkcwA2Z+ta/axHopxE63COJSvQX/Y3n07QHbWNbK+XaKKHChtbA==",
       "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -4381,9 +4381,9 @@
       "integrity": "sha512-3O5oovVIsCrU0tG+WMm6rcmtiGM7tYni/H+oPN1EqLG1B3HPcRiLwypNrHz1w6aQy6vnjB8ovzSJ42taapqN/w=="
     },
     "@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.39.0.tgz",
-      "integrity": "sha512-+9X/Shf6q4DL3Il+vA1f4rwTbOMFTWYs0hdevtL1jAian4CS7lWyQdbACDZdBvNXPrHCvIrOMKDEzuasauiOQg=="
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.39.1.tgz",
+      "integrity": "sha512-JmBsoSX25hsRyYCTei851dkI6zmQnGxi9TrmkcwA2Z+ta/axHopxE63COJSvQX/Y3n07QHbWNbK+XaKKHChtbA=="
     },
     "@eslint-community/eslint-utils": {
       "version": "4.9.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@camunda/element-templates-json-schema": "^0.21.0",
-    "@camunda/zeebe-element-templates-json-schema": "^0.39.0",
+    "@camunda/zeebe-element-templates-json-schema": "^0.39.1",
     "json-source-map": "^0.6.1",
     "min-dash": "^5.0.0"
   }


### PR DESCRIPTION
### Proposed Changes

Related to https://github.com/bpmn-io/bpmn-js-element-templates/pull/233

Update `@camunda/zeebe-element-templates-json-schema` to 0.39.1 and prepare 2.20.1 release

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
