### PR TITLE
feat: deprecate 'optional' property for input mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [element-templates-validator](https://github.com/bpmn-io/
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: deprecate `optional` property for input mappings ([#85](https://github.com/bpmn-io/element-templates-validator/pull/85))
+* `DEPS`: update to `@camunda/zeebe-element-templates-json-schema@0.40.0`
+
+
 # 2.20.1
 
 * `FIX`: restrict usage of template-defined `zeebe:output` bindings when `entriesVisible.outputs === true` ([camunda/element-templates-json-schema#227](https://github.com/camunda/element-templates-json-schema/pull/227))

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@camunda/element-templates-json-schema": "^0.21.0",
-        "@camunda/zeebe-element-templates-json-schema": "^0.39.2",
+        "@camunda/zeebe-element-templates-json-schema": "^0.40.0",
         "json-source-map": "^0.6.1",
         "min-dash": "^5.0.0"
       },
@@ -37,9 +37,9 @@
       "license": "MIT"
     },
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.39.2",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.39.2.tgz",
-      "integrity": "sha512-Cp5gS9vTw3/nZl+2sQ3EU6832rZeimSwXb6CObq0RGW6cX7hfiM57z6yuLRmMbSmHyrQdokE0CLSZ8gfU2feSg==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.40.0.tgz",
+      "integrity": "sha512-XCJp7ijUtQFnUKBYzceDcpLl2CDzc9kKeZ8s/x6UAnlyf/THsg7rH1fYKxGhcxHWAAn4gtBze/0jiXhIZLIMOQ==",
       "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -4381,9 +4381,9 @@
       "integrity": "sha512-3O5oovVIsCrU0tG+WMm6rcmtiGM7tYni/H+oPN1EqLG1B3HPcRiLwypNrHz1w6aQy6vnjB8ovzSJ42taapqN/w=="
     },
     "@camunda/zeebe-element-templates-json-schema": {
-      "version": "0.39.2",
-      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.39.2.tgz",
-      "integrity": "sha512-Cp5gS9vTw3/nZl+2sQ3EU6832rZeimSwXb6CObq0RGW6cX7hfiM57z6yuLRmMbSmHyrQdokE0CLSZ8gfU2feSg=="
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.40.0.tgz",
+      "integrity": "sha512-XCJp7ijUtQFnUKBYzceDcpLl2CDzc9kKeZ8s/x6UAnlyf/THsg7rH1fYKxGhcxHWAAn4gtBze/0jiXhIZLIMOQ=="
     },
     "@eslint-community/eslint-utils": {
       "version": "4.9.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@camunda/element-templates-json-schema": "^0.21.0",
-    "@camunda/zeebe-element-templates-json-schema": "^0.39.2",
+    "@camunda/zeebe-element-templates-json-schema": "^0.40.0",
     "json-source-map": "^0.6.1",
     "min-dash": "^5.0.0"
   }

--- a/test/fixtures/optional-zeebe-input-deprecated.json
+++ b/test/fixtures/optional-zeebe-input-deprecated.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "Optional Zeebe Input Template",
+  "id": "io.camunda.test.optional-zeebe-input",
+  "description": "A template with deprecated optional field with zeebe:input binding.",
+  "appliesTo": [
+    "bpmn:ServiceTask"
+  ],
+  "properties": [
+    {
+      "label": "Request Body",
+      "type": "String",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:input",
+        "name": "body"
+      }
+    }
+  ]
+}

--- a/test/fixtures/optional-zeebe-output.json
+++ b/test/fixtures/optional-zeebe-output.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://unpkg.com/@camunda/zeebe-element-templates-json-schema/resources/schema.json",
+  "name": "Optional Zeebe Output Template",
+  "id": "io.camunda.test.optional-zeebe-output",
+  "appliesTo": [
+    "bpmn:ServiceTask"
+  ],
+  "properties": [
+    {
+      "label": "Result",
+      "type": "String",
+      "optional": true,
+      "binding": {
+        "type": "zeebe:output",
+        "source": "= body"
+      }
+    }
+  ]
+}

--- a/test/spec/validationSpec.js
+++ b/test/spec/validationSpec.js
@@ -554,6 +554,47 @@ describe('Validator', function() {
       });
 
 
+      it('should return warning for deprecated optional field with zeebe:input', function() {
+
+        // given
+        const sample = readFile('test/fixtures/optional-zeebe-input-deprecated.json');
+
+        // when
+        const {
+          valid,
+          errors,
+          warnings
+        } = validateZeebe(sample);
+
+        // then
+        expect(valid).to.be.true;
+        expect(errors).not.to.exist;
+        expect(warnings).to.be.an('array').with.length(1);
+
+        expect(warnings[0]).to.include({
+          keyword: 'deprecated',
+          message: "'optional' with 'zeebe:input' binding is deprecated; an empty input mapping (resolved to 'null') should be used for Camunda 8.8+"
+        });
+      });
+
+
+      it('should not return warning for optional field with other binding types', function() {
+
+        // given
+        const sample = readFile('test/fixtures/optional-zeebe-output.json');
+
+        // when
+        const {
+          valid,
+          warnings
+        } = validateZeebe(sample);
+
+        // then
+        expect(valid).to.be.true;
+        expect(warnings).not.to.exist;
+      });
+
+
       it('should return both errors and warnings', function() {
 
         // given


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-modeler/issues/5840

### Proposed Changes

Integrate new JSON schema and ensure deprecation warnings for 'optional' property with input mappings

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
